### PR TITLE
Use f-string to fix pylint warning

### DIFF
--- a/textract-hand-written-a2i-forms.ipynb
+++ b/textract-hand-written-a2i-forms.ipynb
@@ -352,7 +352,7 @@
     "taskUIName = 'ui-hw-docs-' + timestamp\n",
     "\n",
     "# Flow definition outputs\n",
-    "OUTPUT_PATH = f's3://' + sess.default_bucket() + '/' + prefix + '/a2i-results'"
+    "OUTPUT_PATH = f's3://{sess.default_bucket() }/{prefix}/a2i-results'"
    ]
   },
   {


### PR DESCRIPTION
https://pycodequ.al/docs/pylint-messages/w1309-f-string-without-interpolation.html

*Issue #, if available:*

The current code raise a warning on s3 flow definition outputs
String is defined using f-string but without any interpolation.

*Description of changes:*

Proper use of f-string instead of concatenation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
